### PR TITLE
Fix get_user_first_group for user with no groups

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -104,7 +104,7 @@ def read_user_groups():
 def get_user_first_group(email):
     user_groups_yaml = read_user_groups()
     groups = user_groups_yaml.get("users", {}).get(email, [])
-    if len(groups): return groups[0]
+    if groups != None and len(groups): return groups[0]
     return "default"
 
 


### PR DESCRIPTION
If the email is defined in user-groups.yaml but has no groups, groups is assigned None and len(groups) throws an exception.

Intuitively, one would expect groups to default to [] rather than None because [] is passed as the second argument to Dictionary.get, but this default only applies if the key is not found in the dictionary. In this case the key is defined but has a value of None.