### PR TITLE
Improvements to GET task/:id

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -30,7 +30,9 @@ def get_db():
 def create_archive_task(self, archive_json: str):
     archive = schemas.ArchiveCreate.parse_raw(archive_json)
 
-    if (em := is_group_invalid_for_user(archive.public, archive.group_id, archive.author_id)): return {"error": em}
+    invalid = is_group_invalid_for_user(archive.public, archive.group_id, archive.author_id)
+    if (invalid):
+        raise Exception(invalid) # marks task FAILED, saves the Exception as reult
 
     url = archive.url
     logger.info(f"{url=} {archive=}")
@@ -40,9 +42,10 @@ def create_archive_task(self, archive_json: str):
     try:
         insert_result_into_db(result, archive.tags, archive.public, archive.group_id, archive.author_id, self.request.id)
     except Exception as e:
+        # Log it, then raise again to store the error as the task result
         logger.error(e)
         logger.error(traceback.format_exc())
-        return {"error": e}
+        raise e
     return result.to_dict()
 
 


### PR DESCRIPTION
I wanted to build against the GET task/:id endpoint but found a couple faults with the current implementation. 

1. The code was a little hard to read with several different objects being called a "result" of some kind, so I started with some simple variable renaming.
2. The endpoint would return a json object representing the task but in the result field was a json-encoded string for the result, e.g., `{ id: foo, result: "{status: \"wayback success\", ...}"}`, which the client would then need to parse in order to work with the result. This is an easy fix, just return a dict instead of json string from the worker task.
3. It would sometimes throw an exception while handling an exception, creating a confusing response that did not reveal the underlying issue. This required a bit of refactoring in both the task and the endpoint. Ultimately I found it better to simply throw exceptions in the worker instead of catching and wrapping errors there, and then handle those errors more consistently in get_status.

See also the individual commit messages for more details.