### PR TITLE
Add db task endpoint

### DIFF
--- a/src/db/crud.py
+++ b/src/db/crud.py
@@ -14,12 +14,13 @@ DOMAIN_GROUPS_LOADED = False
 # --------------- TASK = Archive
 
 
-def get_task(db: Session, task_id: str):
-    return base_query(db).filter(models.Archive.id == task_id).first()
-
-
-def get_tasks(db: Session, skip: int = 0, limit: int = 100):
-    return base_query(db).offset(skip).limit(limit).all()
+def get_task(db: Session, task_id: str, email: str):
+    email = email.lower()
+    query = base_query(db).filter(models.Archive.id == task_id)
+    if email != ALLOW_ANY_EMAIL:
+        groups = get_user_groups(db, email)
+        query = query.filter(or_(models.Archive.public == True, models.Archive.author_id == email, models.Archive.group_id.in_(groups)))
+    return query.first()
 
 
 def search_tasks_by_url(db: Session, url: str, email: str, skip: int = 0, limit: int = 100, archived_after: datetime = None, archived_before: datetime = None):

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ load_dotenv()
 
 # Configuration
 ALLOWED_ORIGINS = os.environ.get("ALLOWED_ORIGINS", "chrome-extension://ondkcheoicfckabcnkdgbepofpjmjcmb,chrome-extension://ojcimmjndnlmmlgnjaeojoebaceokpdp").split(",")
-VERSION = "0.5.4"
+VERSION = "0.5.5"
 
 # min-version refers to the version of auto-archiver-extension on the webstore
 BREAKING_CHANGES = {"minVersion": "0.3.1", "message": "The latest update has breaking changes, please update the extension to the most recent version."}
@@ -101,8 +101,8 @@ def archive_tasks(archive:schemas.ArchiveCreate, email = Depends(get_bearer_auth
     return JSONResponse({"id": task.id})
 
 @app.get("/archive/{task_id}")
-def lookup(task_id, db: Session = Depends(get_db), email = Depends(get_bearer_auth)):
-    return crud.get_task(db, task_id)
+def lookup(task_id, db: Session = Depends(get_db), email = Depends(get_bearer_auth_token_or_jwt)):
+    return crud.get_task(db, task_id, email)
 
 @app.get("/tasks/{task_id}")
 def get_status(task_id, email = Depends(get_bearer_auth)):


### PR DESCRIPTION
GET /archive/[id] to retrieve a task from the database, unlike /tasks/[id] which reads the celery task result (from redis) and is only semi-persistent.