### PR TITLE
feat: add referer breakdown metric to Prometheus exporter

### DIFF
--- a/app/tests/web/test_metrics.py
+++ b/app/tests/web/test_metrics.py
@@ -1,0 +1,61 @@
+from http import HTTPStatus
+
+import pytest
+
+from app.web.utils.metrics import (
+    REFERER_COUNTER,
+    increment_referer_counter,
+    normalize_referer,
+)
+
+
+@pytest.mark.parametrize(
+    "referer,expected",
+    [
+        (None, "none"),
+        ("", "none"),
+        (
+            "https://auto-archiver.bellingcat.com/page?id=1",
+            "https://auto-archiver.bellingcat.com",
+        ),
+        ("http://localhost:8081/x", "http://localhost:8081"),
+        ("chrome-extension://abcdef/popup.html", "chrome-extension://abcdef"),
+        ("not-a-valid-referer", "other"),
+        ("/relative/path", "other"),
+    ],
+)
+def test_normalize_referer(referer, expected):
+    assert normalize_referer(referer) == expected
+
+
+def test_increment_referer_counter():
+    def value_for(origin: str) -> float:
+        return (
+            REFERER_COUNTER.labels(referer=origin)._value.get()  # type: ignore[attr-defined]
+        )
+
+    before = value_for("https://example.net")
+    increment_referer_counter("https://example.net/some/path?q=1")
+    increment_referer_counter("https://example.net/another")
+    assert value_for("https://example.net") == before + 2
+
+    before_none = value_for("none")
+    increment_referer_counter(None)
+    assert value_for("none") == before_none + 1
+
+
+def test_referer_counter_via_middleware(client_with_token):
+    # any request flows through the logging middleware, which records the
+    # normalized referer; scrape /metrics (token-protected) to verify it.
+    r = client_with_token.get(
+        "/health",
+        headers={"Referer": "https://referer-test.example/dashboard?x=1"},
+    )
+    assert r.status_code == HTTPStatus.OK
+
+    metrics = client_with_token.get("/metrics")
+    assert metrics.status_code == HTTPStatus.OK
+    assert (
+        'referer_total{referer="https://referer-test.example"} 1.0'
+        in metrics.text
+    )

--- a/app/web/middleware.py
+++ b/app/web/middleware.py
@@ -3,15 +3,17 @@ import traceback
 from fastapi import Request
 
 from app.shared.log import log_error, logger
-from app.web.utils.metrics import EXCEPTION_COUNTER
+from app.web.utils.metrics import (
+    EXCEPTION_COUNTER,
+    increment_referer_counter,
+)
 
 
 async def logging_middleware(request: Request, call_next):
+    # summary prometheus metric on where requests come from
+    increment_referer_counter(request.headers.get("referer"))
     try:
         response = await call_next(request)
-        # TODO: use Origin to have summary prometheus metrics on where
-        #  requests come from
-        # origin = request.headers.get("origin")
         logger.debug(
             f"{request.client.host}:{request.client.port} {request.method} {request.url._url} - HTTP {response.status_code}"
         )

--- a/app/web/utils/metrics.py
+++ b/app/web/utils/metrics.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import shutil
+from urllib.parse import urlparse
 
 from prometheus_client import Counter, Gauge
 
@@ -35,6 +36,34 @@ DATABASE_METRICS_COUNTER = Counter(
     "Database metrics that increase over time",
     labelnames=["query", "user"],
 )
+REFERER_COUNTER = Counter(
+    "referer",
+    "Number of requests received, grouped by their referer origin.",
+    labelnames=["referer"],
+)
+
+
+def normalize_referer(referer: str | None) -> str:
+    """
+    Reduce a raw Referer header to a low-cardinality "scheme://host" origin so
+    it is safe to use as a Prometheus label. The full header is not used
+    directly because it is client-controlled and would let the label set grow
+    without bound (path and query string vary per request).
+
+    Returns "none" when the header is absent and "other" when it cannot be
+    parsed into a scheme + host origin.
+    """
+    if not referer:
+        return "none"
+    parsed = urlparse(referer)
+    if parsed.scheme and parsed.netloc:
+        return f"{parsed.scheme}://{parsed.netloc}"
+    return "other"
+
+
+def increment_referer_counter(referer: str | None) -> None:
+    """Record one request against its normalized referer origin."""
+    REFERER_COUNTER.labels(referer=normalize_referer(referer)).inc()
 
 
 async def redis_subscribe_worker_exceptions(redis_exceptions_channel: str):


### PR DESCRIPTION
Closes #49.

Adds a `referer_total` Prometheus counter that records every incoming request against its referer origin, giving a summary of where traffic comes from. This implements the existing TODO in `logging_middleware`.

The raw `Referer` header is normalized to a `scheme://host` origin before being used as a label so cardinality stays bounded (the header is client-controlled; path/query vary per request). Absent headers bucket into `none`, unparseable ones into `other`.

Note: the issue title says "referer" so I used the `Referer` header. If you'd rather key on `Origin` (more reliably set by the extension clients) it's a one-line change — happy to switch, or record both.

Tests: unit coverage for the normalizer and the counter, plus an end-to-end middleware -> `/metrics` assertion. Full suite passes (`ruff`/`isort` clean).