### PR TITLE
feat: cache commonly hit, rarely changing endpoints

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -37,6 +37,20 @@ def mock_logger_add():
         yield mock_add  # This makes the mock available to tests
 
 
+@pytest.fixture(autouse=True)
+def clear_endpoint_caches():
+    """Clear response caches so cached values never leak between tests."""
+    from app.web.routers import default
+
+    for cache in (
+        default.HOME_CACHE,
+        default.USER_PERMISSIONS_CACHE,
+        default.USER_USAGE_CACHE,
+    ):
+        cache.clear()
+    yield
+
+
 @pytest.fixture()
 def get_settings():
     return Settings(_env_file=".env.test")

--- a/app/tests/web/test_cache.py
+++ b/app/tests/web/test_cache.py
@@ -1,0 +1,169 @@
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import pytest
+from cachetools import TTLCache
+from fastapi.testclient import TestClient
+
+from app.shared.schemas import Usage, UsageResponse
+from app.web.routers import default
+from app.web.security import get_user_state
+from app.web.utils.cache import cached_endpoint
+
+
+# --- unit tests for the decorator ------------------------------------------
+
+
+def test_cached_endpoint_sync_caches_by_key():
+    cache = TTLCache(maxsize=8, ttl=60)
+    calls = []
+
+    @cached_endpoint(cache, key=lambda user: user)
+    def endpoint(user):
+        calls.append(user)
+        return f"result-{user}"
+
+    assert endpoint(user="a") == "result-a"
+    assert endpoint(user="a") == "result-a"  # served from cache
+    assert calls == ["a"]  # body ran only once
+
+    assert endpoint(user="b") == "result-b"  # different key, recomputed
+    assert calls == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_cached_endpoint_async_caches():
+    cache = TTLCache(maxsize=8, ttl=60)
+    calls = []
+
+    @cached_endpoint(cache, key=lambda: "const")
+    async def endpoint():
+        calls.append(1)
+        return "value"
+
+    assert await endpoint() == "value"
+    assert await endpoint() == "value"
+    assert len(calls) == 1
+
+
+def test_cached_endpoint_does_not_cache_exceptions():
+    cache = TTLCache(maxsize=8, ttl=60)
+    calls = []
+
+    @cached_endpoint(cache, key=lambda: "k")
+    def endpoint():
+        calls.append(1)
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        endpoint()
+    with pytest.raises(ValueError):
+        endpoint()
+    assert len(calls) == 2  # re-evaluated, error never cached
+
+
+# --- endpoint-level behaviour ----------------------------------------------
+
+
+def _usage(monthly_urls: int) -> UsageResponse:
+    return UsageResponse(
+        monthly_urls=monthly_urls,
+        monthly_mbs=0,
+        total_sheets=0,
+        groups={"g": Usage(monthly_urls=monthly_urls)},
+    )
+
+
+def test_user_usage_is_cached(app):
+    user = MagicMock()
+    user.active = True
+    user.email = "alice@example.com"
+    user.usage.return_value = _usage(1)
+
+    app.dependency_overrides[get_user_state] = lambda: user
+    client = TestClient(app)
+
+    r1 = client.get("/user/usage")
+    r2 = client.get("/user/usage")
+    assert r1.status_code == r2.status_code == HTTPStatus.OK
+    assert r1.json() == r2.json()
+    # second request was served from cache, so usage() ran only once
+    assert user.usage.call_count == 1
+
+
+def test_user_usage_is_isolated_per_user(app):
+    alice = MagicMock()
+    alice.active = True
+    alice.email = "alice@example.com"
+    alice.usage.return_value = _usage(11)
+
+    bob = MagicMock()
+    bob.active = True
+    bob.email = "bob@example.com"
+    bob.usage.return_value = _usage(22)
+
+    client = TestClient(app)
+
+    app.dependency_overrides[get_user_state] = lambda: alice
+    r_alice = client.get("/user/usage")
+
+    app.dependency_overrides[get_user_state] = lambda: bob
+    r_bob = client.get("/user/usage")
+
+    assert r_alice.json()["monthly_urls"] == 11
+    assert r_bob.json()["monthly_urls"] == 22  # not alice's cached value
+
+    # a fresh object for alice must hit her cached entry, not recompute
+    alice_again = MagicMock()
+    alice_again.active = True
+    alice_again.email = "alice@example.com"
+    alice_again.usage.return_value = _usage(999)
+    app.dependency_overrides[get_user_state] = lambda: alice_again
+    r_alice_again = client.get("/user/usage")
+    assert r_alice_again.json()["monthly_urls"] == 11  # cached, not 999
+    assert alice_again.usage.call_count == 0
+
+
+def test_user_usage_inactive_error_is_not_cached(app):
+    user = MagicMock()
+    user.email = "carol@example.com"
+    user.active = False
+    user.usage.return_value = _usage(5)
+
+    app.dependency_overrides[get_user_state] = lambda: user
+    client = TestClient(app)
+
+    r_forbidden = client.get("/user/usage")
+    assert r_forbidden.status_code == HTTPStatus.FORBIDDEN
+
+    # once active, the previously-raised 403 must not have been cached
+    user.active = True
+    r_ok = client.get("/user/usage")
+    assert r_ok.status_code == HTTPStatus.OK
+    assert r_ok.json()["monthly_urls"] == 5
+
+
+def test_user_permissions_is_cached(app):
+    from app.shared.user_groups import GroupInfo
+
+    user = MagicMock()
+    user.email = "dave@example.com"
+    perms = {"all": GroupInfo(read=True)}
+    type(user).permissions = property(lambda self: perms)
+
+    app.dependency_overrides[get_user_state] = lambda: user
+    client = TestClient(app)
+
+    r1 = client.get("/user/permissions")
+    r2 = client.get("/user/permissions")
+    assert r1.status_code == r2.status_code == HTTPStatus.OK
+    assert r1.json() == r2.json()
+    assert default.USER_PERMISSIONS_CACHE["dave@example.com"] is perms
+
+
+def test_home_endpoint_is_cached(client_with_auth):
+    r1 = client_with_auth.get("/")
+    r2 = client_with_auth.get("/")
+    assert r1.status_code == r2.status_code == HTTPStatus.OK
+    assert r1.json() == r2.json()
+    assert "home" in default.HOME_CACHE

--- a/app/web/routers/default.py
+++ b/app/web/routers/default.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from typing import Dict
 
+from cachetools import TTLCache
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse, JSONResponse
 
@@ -9,12 +10,21 @@ from app.shared.user_groups import GroupInfo
 from app.web.config import BREAKING_CHANGES, VERSION
 from app.web.db.user_state import UserState
 from app.web.security import get_user_state
+from app.web.utils.cache import cached_endpoint
 
 
 router = APIRouter()
 
+# Response caches for hot, rarely-changing endpoints. User-scoped caches are
+# keyed by the authenticated user's email so responses are never shared across
+# users. TTLs are short enough that stale data self-corrects quickly.
+HOME_CACHE = TTLCache(maxsize=1, ttl=300)
+USER_PERMISSIONS_CACHE = TTLCache(maxsize=1024, ttl=300)
+USER_USAGE_CACHE = TTLCache(maxsize=1024, ttl=60)
+
 
 @router.get("/")
+@cached_endpoint(HOME_CACHE, key=lambda: "home")
 async def home() -> JSONResponse:
     return JSONResponse(
         {"version": VERSION, "breakingChanges": BREAKING_CHANGES}
@@ -39,6 +49,7 @@ async def active(
     "/user/permissions",
     summary="Get the user's global 'all' permissions and the permissions for each group they belong to.",
 )
+@cached_endpoint(USER_PERMISSIONS_CACHE, key=lambda user: user.email)
 def get_user_permissions(
     user: UserState = Depends(get_user_state),
 ) -> Dict[str, GroupInfo]:
@@ -49,6 +60,7 @@ def get_user_permissions(
     "/user/usage",
     summary="Get the user's monthly URLs/MBs usage along with the total active sheets, breakdown by group.",
 )
+@cached_endpoint(USER_USAGE_CACHE, key=lambda user: user.email)
 def get_user_usage(
     user: UserState = Depends(get_user_state),
 ) -> UsageResponse:

--- a/app/web/utils/cache.py
+++ b/app/web/utils/cache.py
@@ -1,0 +1,52 @@
+import functools
+import inspect
+from typing import Callable
+
+from cachetools import TTLCache
+
+
+def cached_endpoint(cache: TTLCache, key: Callable[..., object]):
+    """
+    Cache a FastAPI endpoint's return value in a time-bounded ``TTLCache``.
+
+    ``key`` receives the same arguments FastAPI injects into the endpoint (its
+    resolved dependencies) and must return a hashable cache key. For per-user
+    endpoints the key MUST include a stable user identifier so one user can
+    never be served another user's cached response.
+
+    Only successful return values are cached: if the endpoint raises (e.g. an
+    ``HTTPException``) the error propagates and nothing is stored, so the next
+    request re-evaluates the endpoint.
+
+    ``functools.wraps`` keeps the original signature visible to FastAPI so
+    dependency injection, response models and auth all keep working; the wrapper
+    matches the sync/async nature of the wrapped endpoint so its execution model
+    (threadpool vs event loop) is preserved.
+    """
+
+    def decorator(func):
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                cache_key = key(*args, **kwargs)
+                if cache_key in cache:
+                    return cache[cache_key]
+                result = await func(*args, **kwargs)
+                cache[cache_key] = result
+                return result
+
+            return async_wrapper
+
+        @functools.wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            cache_key = key(*args, **kwargs)
+            if cache_key in cache:
+                return cache[cache_key]
+            result = func(*args, **kwargs)
+            cache[cache_key] = result
+            return result
+
+        return sync_wrapper
+
+    return decorator


### PR DESCRIPTION
Closes #50. (cc @michplunkett — you'd mentioned taking this one; happy to hand off or collaborate if you're still on it.)

Adds response caching to the hot GET endpoints the extension hits on every load: `/`, `/user/permissions`, `/user/usage`, avoiding a repeated DB aggregation on each request.

**Implementation note / open question:** the issue links `fastapi-cache`, but I built this on `cachetools`, which is already a dependency here. `fastapi-cache` would add a new dependency, need lifespan backend setup, and require a custom per-user key builder plus async endpoints to get the same isolation. If you'd prefer `fastapi-cache` (e.g. for a Redis-backed cache shared across workers), I'm glad to redo it that way — just let me know.

**Safety:**
- User-scoped caches are keyed by the authenticated user's email, so responses are never shared across users (there's a dedicated regression test for this).
- The auth dependency still runs on every request, so cache hits don't bypass authentication.
- Endpoint errors (the inactive-user `403`) are never cached.

Caches are in-process per worker with short TTLs (usage 60s, permissions/home 300s), matching the issue's note that these values "won't change every minute". Full suite passes with 8 new tests; `ruff`/`isort` clean.